### PR TITLE
Added extra configurations to client calls

### DIFF
--- a/packages/clients/data.ts
+++ b/packages/clients/data.ts
@@ -1,5 +1,6 @@
 import { SNI_API_URL } from '@sni/constants';
-import axios, { AxiosRequestConfig } from 'axios';
+import type { AxiosRequestConfig } from 'axios';
+import axios from 'axios';
 
 export function getEntity(
   collection: string,

--- a/packages/clients/link.ts
+++ b/packages/clients/link.ts
@@ -1,15 +1,19 @@
 import { SNI_API_URL } from '@sni/constants';
 
 import { stringToId } from '@sni/address-utils';
+import type { AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 
 const API_URL = `${SNI_API_URL}/items/links`;
 
-export function getLinkById(id: string) {
-  return axios.get(`${API_URL}/${id}`);
+export function getLinkById(id: string, config: AxiosRequestConfig = {}) {
+  return axios.get(`${API_URL}/${id}`, config);
 }
 
-export function getLinkByAddress(address: string) {
+export function getLinkByAddress(
+  address: string,
+  config: AxiosRequestConfig = {}
+) {
   const id = stringToId(address);
-  return axios.get(`${API_URL}/${id}`);
+  return axios.get(`${API_URL}/${id}`, config);
 }

--- a/packages/clients/nft/index.ts
+++ b/packages/clients/nft/index.ts
@@ -19,7 +19,7 @@ function getKusamaNft(id: string) {
 export function getNftData(
   network: string,
   collectionAddress: string,
-  tokenId: string
+  tokenId: number
 ) {
   switch (network) {
     case 'polkadot':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       '@sni/address-utils':
         specifier: workspace:*
         version: link:../../packages/address-utils
+      '@sni/clients':
+        specifier: workspace:*
+        version: link:../../packages/clients
       '@sveltejs/adapter-auto':
         specifier: 2.1.0
         version: 2.1.0(@sveltejs/kit@1.25.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,9 +159,6 @@ importers:
       '@sni/address-utils':
         specifier: workspace:*
         version: link:../../packages/address-utils
-      '@sni/clients':
-        specifier: workspace:*
-        version: link:../../packages/clients
       '@sveltejs/adapter-auto':
         specifier: 2.1.0
         version: 2.1.0(@sveltejs/kit@1.25.0)


### PR DESCRIPTION
Added configuration options for client calls.

Adjusted the type of [ token ID ](packages/clients/nft/index.ts) to match the `address-utilities` response type.  
