### PR TITLE
Extra checks to prevent errors on undefined img url

### DIFF
--- a/apps/verification-portal/src/lib/components/NFTImage.svelte
+++ b/apps/verification-portal/src/lib/components/NFTImage.svelte
@@ -32,6 +32,9 @@
 
   //check if id or url
   function isUrl(url: string): boolean {
+    if (!url) {
+      return false;
+    }
     return (
       url.toLowerCase().startsWith('https://') ||
       url.toLowerCase().startsWith('http://')

--- a/apps/verification-portal/src/lib/utils.ts
+++ b/apps/verification-portal/src/lib/utils.ts
@@ -56,7 +56,7 @@ function getCID(url: string): string {
 }
 
 export function isIPFSUrl(url: string): boolean {
-  return url.startsWith('ipfs://');
+  return url !== undefined && url.startsWith('ipfs://');
 }
 
 import { goto } from '$app/navigation';


### PR DESCRIPTION
Fixed unhandled error on `TypeError: Cannot read properties of undefined (reading 'startsWith')` on asset page due when image url is undefined 