### PR TITLE
Line wrap for paragraph elements

### DIFF
--- a/apps/verification-portal/src/app.postcss
+++ b/apps/verification-portal/src/app.postcss
@@ -16,6 +16,10 @@ h6 {
   @apply font-serif font-normal;
 }
 
+p {
+  white-space: pre-wrap;
+}
+
 /* //@TODO get aeonik med varioation */
 @font-face {
   font-family: 'Clearface Serial';


### PR DESCRIPTION
@smakhtin we should perhaps consider more elaborate text formatting handling (bold, italic, links and paragraphs) , but this fixes the newlines for now in the asset page paragraphs 

![image](https://github.com/sovereign-nature/deep/assets/34912439/125a1db8-4093-4cf6-825d-0fd6289c7c4b)
