### PR TITLE
LInk to claim address via standard card header component

### DIFF
--- a/apps/verification-portal/src/lib/shared/i18n/i18n-types.ts
+++ b/apps/verification-portal/src/lib/shared/i18n/i18n-types.ts
@@ -52,6 +52,10 @@ type RootTranslation = {
 	 * S​e​l​e​c​t​ ​t​h​i​s​ ​t​o​k​e​n
 	 */
 	selectToken: string
+	/**
+	 * S​e​a​r​c​h​ ​f​o​r​ ​t​o​k​e​n​s
+	 */
+	searchForTokens: string
 	results: {
 		/**
 		 * S​h​o​w​i​n​g​ ​r​e​s​u​l​t​s​ ​f​o​r
@@ -416,9 +420,22 @@ type RootTranslation = {
 		 */
 		light: string
 		/**
-		 * N​i​g​h​t​ ​M​o​d​e
+		 * L​i​g​h​t
+		 */
+		lightSm: string
+		/**
+		 * D​a​r​k​ ​M​o​d​e
 		 */
 		dark: string
+		/**
+		 * D​a​r​k
+		 */
+		darkSm: string
+		/**
+		 * S​w​i​t​c​h​ ​M​o​d​e​ ​(​{​n​a​m​e​}​)
+		 * @param {string} name
+		 */
+		switchTheme: RequiredParams<'name'>
 	}
 	errors: {
 		/**
@@ -486,6 +503,10 @@ export type TranslationFunctions = {
 	 * Select this token
 	 */
 	selectToken: () => LocalizedString
+	/**
+	 * Search for tokens
+	 */
+	searchForTokens: () => LocalizedString
 	results: {
 		/**
 		 * Showing results for
@@ -841,9 +862,21 @@ export type TranslationFunctions = {
 		 */
 		light: () => LocalizedString
 		/**
-		 * Night Mode
+		 * Light
+		 */
+		lightSm: () => LocalizedString
+		/**
+		 * Dark Mode
 		 */
 		dark: () => LocalizedString
+		/**
+		 * Dark
+		 */
+		darkSm: () => LocalizedString
+		/**
+		 * Switch Mode ({name})
+		 */
+		switchTheme: (arg: { name: string }) => LocalizedString
 	}
 	errors: {
 		/**

--- a/apps/verification-portal/src/lib/shared/typography/CardHeader.svelte
+++ b/apps/verification-portal/src/lib/shared/typography/CardHeader.svelte
@@ -2,15 +2,15 @@
   import LinkIcon from '$lib/components/icons/LinkIcon.svelte';
   export let className: string = '';
   export let title: string = '';
-  export let url: string = '';
+  export let url: string | URL = '';
 </script>
 
 <slot />
 
 {#if url}
-  <a class={className} href={url} target="_blank" {title}
+  <a href={url} target="_blank" {title}
     ><h3
-      class="transition-color text-primary-400 hover:text-primary-300 dark:text-primary-300 dark:hover:text-primary-200 mb-3 flex flex-row items-baseline gap-2 text-[26px] underline md:text-3xl leading-tight"
+      class={`${className} transition-color text-primary-400 hover:text-primary-300 dark:text-primary-300 dark:hover:text-primary-200 mb-3 flex flex-row items-baseline gap-2 text-[26px] underline md:text-3xl leading-tight`}
     >
       {title}
       <LinkIcon className="w-5 h-5" />

--- a/apps/verification-portal/src/lib/widgets/NFTClaim/ClaimData.svelte
+++ b/apps/verification-portal/src/lib/widgets/NFTClaim/ClaimData.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getNFTClaimContext } from './context';
   import { LL } from '$lib/shared/i18n/i18n-svelte';
-
+  import CardHeader from '$lib/shared/typography/CardHeader.svelte';
   import Property from '$lib/shared/typography/Property.svelte';
   import NftImage from '$lib/components/NFTImage.svelte';
   import ImagePlaceholder from '$lib/components/ImagePlaceholder.svelte';
@@ -21,7 +21,11 @@
 
     <div>
       <div>
-        <h2 class="text-2xl">{$claimResponse?.metadata?.name}</h2>
+        <CardHeader
+          className="mb-0"
+          title={$claimResponse?.metadata?.name}
+          url={$claimResponse?.metadata?.address}
+        />
         <p>{$claimResponse?.metadata?.description}</p>
         <slot />
         {#if $claimResponse?.onChain}

--- a/apps/verification-portal/src/lib/widgets/NFTClaim/ClaimForm.svelte
+++ b/apps/verification-portal/src/lib/widgets/NFTClaim/ClaimForm.svelte
@@ -145,7 +145,7 @@
           bind:group={$formUseWallet}
           value={true}
         />
-        <span class="ml-1 flex gap-4 items-center">
+        <span class="ml-1 flex flex-wrap gap-4 items-center">
           {#if $web3Connected}
             {$LL.claim.useWallet()}
           {/if}

--- a/apps/verification-portal/src/lib/widgets/NFTClaim/NFTClaim.svelte
+++ b/apps/verification-portal/src/lib/widgets/NFTClaim/NFTClaim.svelte
@@ -57,7 +57,7 @@
     'bg-deep-green text-white border-none max-h-[96%] h-[96%] sm:h-auto pb-4 z-drawer';
   const drawerHeaderClass =
     'container px-5 lg:px-0 pt-4 pb-8 relative w-full lg:w-4/5 mx-auto';
-  const drawerTitleClass = 'text-2xl lg:text-3xl font-normal me-8 sm:me-auto';
+  const drawerTitleClass = 'text-[26px]  font-normal me-8 sm:me-auto';
   const drawerBodyClass =
     'container pb-10 px-5 lg:px-0 sticky top-0 w-full lg:w-4/5 mx-auto';
 

--- a/apps/verification-portal/src/lib/widgets/NFTClaim/context.ts
+++ b/apps/verification-portal/src/lib/widgets/NFTClaim/context.ts
@@ -6,6 +6,7 @@ export type CrossmintResponse = {
     name: string;
     description: string;
     image: string;
+    address: URL;
   };
   onChain: {
     status: string;


### PR DESCRIPTION
If address prop exists the link will be rendered otherwise it will display as standard component 
@smakhtin will it need the app url prefix still?

![image](https://github.com/sovereign-nature/deep/assets/34912439/98582698-d202-458e-9688-f5d7dd6d1276)
