### PR TITLE
Reverted Flowbite dep to 2.3.0 to fix server error bug

### DIFF
--- a/apps/verification-portal/package.json
+++ b/apps/verification-portal/package.json
@@ -49,7 +49,7 @@
     "@web3modal/wagmi": "4.2.3",
     "autoprefixer": "10.4.19",
     "date-fns": "3.6.0",
-    "flowbite": "2.4.1",
+    "flowbite": "2.3.0",
     "flowbite-svelte": "0.46.13",
     "fuse.js": "7.0.0",
     "graphql-request": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
         specifier: 3.6.0
         version: 3.6.0
       flowbite:
-        specifier: 2.4.1
-        version: 2.4.1(rollup@2.79.1)
+        specifier: 2.3.0
+        version: 2.3.0
       flowbite-svelte:
         specifier: 0.46.13
         version: 0.46.13(rollup@2.79.1)(svelte@4.2.18)
@@ -9739,7 +9739,7 @@ packages:
     resolution: {integrity: sha512-CLVqzuoE2vkUvWYK/lJ6GzT0be5dlTbH3uuhVwyB67+PjqJWABm2wv68xhBf5BqjpBxvTSQ3mrmLHpPJ2tvrSQ==}
     dependencies:
       '@rollup/plugin-node-resolve': 15.2.3(rollup@2.79.1)
-      flowbite: 2.4.1(rollup@2.79.1)
+      flowbite: 2.3.0
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -9757,6 +9757,13 @@ packages:
       tailwind-merge: 2.3.0
     transitivePeerDependencies:
       - rollup
+    dev: true
+
+  /flowbite@2.3.0:
+    resolution: {integrity: sha512-pm3JRo8OIJHGfFYWgaGpPv8E+UdWy0Z3gEAGufw+G/1dusaU/P1zoBLiQpf2/+bYAi+GBQtPVG86KYlV0W+AFQ==}
+    dependencies:
+      '@popperjs/core': 2.11.8
+      mini-svg-data-uri: 1.4.4
     dev: true
 
   /flowbite@2.4.1(rollup@2.79.1):


### PR DESCRIPTION
Flowbite 2.4.1 version has a bug with datepicker causing server crash:
See related Issues:
https://github.com/themesberg/flowbite/issues/918
https://github.com/themesberg/flowbite-datepicker/issues/41

Reverted Flowbite back to 2.3.0 

Still a question why did it manifest only on the "Un-linked" asset page and why on production env the standard 500 page is not shown but a white crash page, any thoughts?
![image](https://github.com/sovereign-nature/deep/assets/34912439/af25877a-49f4-446c-91e9-2f08668e351b)

Test link:
https://real.sovereignnature.com/assets/did:asset:deep:polkadot.asset-hub:1:1