### PR TITLE
Custom configurations for button components  for Umami event tracking

### DIFF
--- a/apps/verification-portal/src/lib/shared/components/RolloverBtn.svelte
+++ b/apps/verification-portal/src/lib/shared/components/RolloverBtn.svelte
@@ -15,7 +15,10 @@
   export let customIconClass: string = '';
   export let customLabelClass: string = '';
   export let disabled: boolean = false;
-
+  export let umamiID: string = '';
+  export let umamiEvent: string = 'rollover-button-click';
+  $: umamiSuffix = umamiID ? `-${umamiID}` : '';
+  $: umamiEventPath = `${umamiEvent}${umamiSuffix}`;
   $: isAlert = hasNew;
 
   let colorClasses = {
@@ -52,7 +55,7 @@
   <div class="relative">
     <button
       type="button"
-      data-umami-event="rollover-button-click"
+      data-umami-event={umamiEventPath}
       {disabled}
       class={`${btnClass} ${$$slots.default && isOpen ? 'open' : 'closed'}`}
       on:click={() => {

--- a/apps/verification-portal/src/lib/widgets/ButtonInboxConnect/Web3Notifications.svelte
+++ b/apps/verification-portal/src/lib/widgets/ButtonInboxConnect/Web3Notifications.svelte
@@ -79,6 +79,7 @@
   <RolloverBtn
     type="alert"
     className="text-xs"
+    umamiEvent="notifications-button-click"
     customBtnClass={responsive ? 'h-8 md:h-11 md:text-base text-sm' : ''}
     disabled={$web3InboxLoading || $web3InboxEnabling}
     hasNew={$web3InboxRegistered && $web3InboxSubscribed ? hasMessages : false}

--- a/apps/verification-portal/src/lib/widgets/ButtonWalletConnect/Web3ConnectBtn.svelte
+++ b/apps/verification-portal/src/lib/widgets/ButtonWalletConnect/Web3ConnectBtn.svelte
@@ -11,6 +11,9 @@
   export let alwaysOpen = false;
   export let responsive = false;
   export let buttonClass = '';
+  export let umamiID: string = '';
+  const connectClickEvent = 'wallet-connect-click';
+  const modalOpenEvent = 'web3modal-open';
 
   const web3Connected: Writable<boolean> = getContext('web3Connected');
   const web3Address: Writable<string> = getContext('web3Address');
@@ -33,7 +36,7 @@
         class={`${responsive ? 'h-8 md:h-11 md:text-base text-xs px-3 md:px-5' : 'text-base h-11 px-5'} text-white dark:text-primary-200 hover:bg-primary-300   hover:dark:bg-deep-green-400 active:opacity-100 flex items-center gap-2 rounded-full bg-primary-400 dark:bg-deep-green-500`}
         type="button"
         on:click={openModal}
-        data-umami-event="web3modal-open"
+        data-umami-event={modalOpenEvent}
       >
         <span class="flex items-center gap-2">
           <span
@@ -48,6 +51,8 @@
       type="primary"
       className="text-sm sm:text-base"
       keepOpen={alwaysOpen}
+      umamiEvent={connectClickEvent}
+      {umamiID}
       on:click={() => openModal()}
       customBtnClass={responsive
         ? 'h-8 md:h-11 md:text-base text-sm ' + buttonClass

--- a/apps/verification-portal/src/lib/widgets/DOTphin/Steps/CardEvolution.svelte
+++ b/apps/verification-portal/src/lib/widgets/DOTphin/Steps/CardEvolution.svelte
@@ -30,6 +30,7 @@
       <CardTitle content={$LL.multipass.state.evolveStep.COMPLETE.title()} />
     {:else}
       <TimelineActionButton
+        umamiID="evolution"
         disabled={$multipassStepConfig.evolution.stepStatus !== 'active'}
         title={$LL.multipass.state.evolveStep.INITIAL.cta()}
       />

--- a/apps/verification-portal/src/lib/widgets/DOTphin/Steps/CardNFT.svelte
+++ b/apps/verification-portal/src/lib/widgets/DOTphin/Steps/CardNFT.svelte
@@ -30,6 +30,7 @@
   >
     <svelte:fragment slot="header">
       <TimelineActionButton
+        umamiID="collect-orbo"
         disabled={$multipassStepConfig.nft.stepStatus !== 'active'}
         title={$LL.multipass.state.nftStep.UNCLAIMED.cta()}
         on:click={() => openModal()}

--- a/apps/verification-portal/src/lib/widgets/DOTphin/Steps/CardProof.svelte
+++ b/apps/verification-portal/src/lib/widgets/DOTphin/Steps/CardProof.svelte
@@ -58,7 +58,7 @@
   >
     <svelte:fragment slot="header">
       <div class="flex flex-row justify-start md:justify-center">
-        <Web3ConnectBtn alwaysOpen />
+        <Web3ConnectBtn umamiID="DOTphin-widget" alwaysOpen />
       </div>
     </svelte:fragment>
 

--- a/apps/verification-portal/src/lib/widgets/DOTphin/TimelineItem/TimelineActionButton.svelte
+++ b/apps/verification-portal/src/lib/widgets/DOTphin/TimelineItem/TimelineActionButton.svelte
@@ -2,6 +2,10 @@
   import { createEventDispatcher } from 'svelte';
   export let title: string;
   export let disabled: boolean = false;
+  export let umamiID: string = '';
+  export let umamiEvent: string = 'dotphin-timeline-action-button-click';
+  $: umamiSuffix = umamiID ? `-${umamiID}` : '';
+  $: umamiEventPath = `${umamiEvent}${umamiSuffix}`;
   const dispatch = createEventDispatcher();
 
   const baseClass = `px-4 py-2 rounded-full whitespace-nowrap drop-shadow-sm font-aeonik text-base`;
@@ -11,7 +15,7 @@
 
 <button
   type="button"
-  data-umami-event="dotphin-timeline-action-button-click"
+  data-umami-event={umamiEventPath}
   class={`${baseClass} ${disabled ? disabledClass : activeClass}`}
   on:click={() => dispatch('click')}
   {disabled}>{title}</button

--- a/apps/verification-portal/src/lib/widgets/NFTClaim/ClaimForm/InputAddress.svelte
+++ b/apps/verification-portal/src/lib/widgets/NFTClaim/ClaimForm/InputAddress.svelte
@@ -25,6 +25,9 @@
   $: address =
     $web3Connected && $formUseWallet ? $web3Address : $formManualAddress;
   $: showEmailClass = showEmailField ? 'w-full' : 'h-16 ';
+  $: umamiEvent = $formUseWallet
+    ? 'nft-claim-submit-wallet'
+    : 'nft-claim-submit-manual';
 </script>
 
 <div
@@ -47,7 +50,10 @@
   {:else if $formUseWallet}
     <div>
       <span class="block pb-2">{$LL.claim.labelConnectWallet()}</span>
-      <Web3ConnectBtn buttonClass=" w-64 justify-center" alwaysOpen
+      <Web3ConnectBtn
+        umamiID="NFT-Claim"
+        buttonClass=" w-64 justify-center"
+        alwaysOpen
       ></Web3ConnectBtn>
     </div>
   {:else}
@@ -115,7 +121,7 @@
       tabindex="3"
       formaction="/?/claim"
       disabled={$formSending}
-      data-umami-event="nft-claim-submit"
+      data-umami-event={umamiEvent}
     >
       {$LL.claim.buttonSubmit()}
       {#if $formSending}

--- a/apps/verification-portal/src/lib/widgets/Navbar/NavBar.svelte
+++ b/apps/verification-portal/src/lib/widgets/Navbar/NavBar.svelte
@@ -65,7 +65,7 @@
   <div class="ms-auto flex flex-row gap-x-2 sm:gap-x-4 text-white">
     <Web3Notifications responsive></Web3Notifications>
 
-    <BtnWeb3Connect responsive></BtnWeb3Connect>
+    <BtnWeb3Connect umamiID="navbar" responsive></BtnWeb3Connect>
     <ThemeSwitch className="hidden md:flex"></ThemeSwitch>
     <Hamburger open={menuOpen} on:click={() => (menuOpen = !menuOpen)} />
   </div>

--- a/apps/verification-portal/src/lib/widgets/ThemeSwitch/Menu.svelte
+++ b/apps/verification-portal/src/lib/widgets/ThemeSwitch/Menu.svelte
@@ -25,6 +25,7 @@
 </script>
 
 <RolloverBtn
+  umamiEvent="theme-mode-switch"
   type="secondary"
   keepOpen={dropdownOpen}
   customBtnClass={`${containerClass} theme-rollover  flex items-center `}


### PR DESCRIPTION
- more granual event path construction for rolloverBtn and StepAction btn
-- default event prefix override option
-- optional chained event id suffix 

- Added tracking for manual vs wallet claiming submitt

**Example:**
_BtnWeb3Connect component_ 

```
 export let umamiID: string = ''; //  exported prop, to be used eg. `navbar`, `DOTphin-widget`
 const connectClickEvent = 'wallet-connect-click';
[..]
 <RolloverBtn
      umamiEvent={connectClickEvent}
      {umamiID}
[...]
```
_Usage_ 
```
    <BtnWeb3Connect umamiID="navbar" />
```
